### PR TITLE
Fix and implement telegram bot auto forwarding

### DIFF
--- a/bot_new.py
+++ b/bot_new.py
@@ -756,7 +756,7 @@ class TelethonManager:
         return client, sent_code.phone_code_hash
 
     @classmethod
-    async def complete_login(cls, user_id: int, auth_code: str, phone_code_hash: str) -> Union[str, Literal["2fa_required"]]:
+    async def complete_login(cls, user_id: int, auth_code: str, phone_code_hash: str) -> str:
         client = cls._active_clients.get(user_id)
         if not client:
             raise ValueError("No active client session found for this user. Please restart login.")
@@ -765,8 +765,9 @@ class TelethonManager:
             await client.sign_in(code=auth_code, phone_code_hash=phone_code_hash)
             session_string = client.session.save()
             return session_string
-        except SessionPasswordNeededError:
-            return "2fa_required"
+        except SessionPasswordNeededError as e:
+            # Propagate 2FA requirement to caller to handle asking for password
+            raise e
         except (PhoneCodeExpiredError, PhoneCodeInvalidError, FloodWaitError) as e:
             await client.disconnect()
             cls._active_clients.pop(user_id, None)
@@ -2737,7 +2738,18 @@ async def get_auth_code(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     try:
         session_string = await TelethonManager.complete_login(user_id, auth_code, phone_code_hash)
         user_profile = db.get_user(user_id)
-        if user_profile:
+        if user_profile is None:
+            user_profile = UserProfile(
+                user_id=user_id,
+                username=update.effective_user.username or "",
+                first_name=update.effective_user.first_name or "",
+                last_name=update.effective_user.last_name or "",
+                joined_date=get_current_time(),
+                last_active=get_current_time(),
+                telethon_session=session_string
+            )
+            db.save_user(user_profile)
+        else:
             user_profile.telethon_session = session_string
             db.save_user(user_profile)
         await update.message.reply_text("✅ Your Telegram account has been successfully connected! 🎉")
@@ -2763,7 +2775,18 @@ async def get_2fa_password(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     try:
         session_string = await TelethonManager.complete_2fa(user_id, password)
         user_profile = db.get_user(user_id)
-        if user_profile:
+        if user_profile is None:
+            user_profile = UserProfile(
+                user_id=user_id,
+                username=update.effective_user.username or "",
+                first_name=update.effective_user.first_name or "",
+                last_name=update.effective_user.last_name or "",
+                joined_date=get_current_time(),
+                last_active=get_current_time(),
+                telethon_session=session_string
+            )
+            db.save_user(user_profile)
+        else:
             user_profile.telethon_session = session_string
             db.save_user(user_profile)
         await update.message.reply_text("✅ Your Telegram account has been successfully connected! 🎉")


### PR DESCRIPTION
Fix user account login and session persistence to enable successful Telegram account connection and forwarding.

The previous implementation of `TelethonManager.complete_login` did not properly propagate 2FA requirements, and the session saving logic in `get_auth_code` and `get_2fa_password` was incomplete. This prevented successful user account login and session retention for forwarding. This PR ensures the bot can correctly handle 2FA and persist the user's Telethon session.

---
<a href="https://cursor.com/background-agent?bcId=bc-260767e8-356e-4676-bd67-f9e0f5e411c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-260767e8-356e-4676-bd67-f9e0f5e411c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>